### PR TITLE
Set errorFired flag on timeout

### DIFF
--- a/lib/ntp-client.js
+++ b/lib/ntp-client.js
@@ -50,6 +50,7 @@
         var timeout = setTimeout(function () {
             client.close();
             callback("Timeout waiting for NTP response.", null);
+            errorFired = true;
         }, exports.ntpReplyTimeout);
 
         // Some errors can happen before/after send() or cause send() to was impossible.


### PR DESCRIPTION
An 'error' callback can occur after the setTimeout() fires in rare occasions,
which should be ignored to prevent multiple error callbacks.
