### PR TITLE
Add NTP stratum info

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Pure Javascript implementation of the NTP Client Protocol
 ## Getting Started
 Install the module with: `npm install ntp-client`
 
+## Examples
+### Get just the time
 ```javascript
 var ntpClient = require('ntp-client');
 
@@ -19,9 +21,28 @@ ntpClient.getNetworkTime("pool.ntp.org", 123, function(err, date) {
 });
 ```
 
+### Get the time and the server's stratum
+Get the server's startum:
+```javascript
+var ntpClient = require('ntp-client');
+
+ntpClient.getNetworkTime("pool.ntp.org", 123, function(err, date, stratum) {
+    if(err) {
+        console.error(err);
+        return;
+    }
+
+    console.log("Current time : ");
+    console.log(date); // Mon Jul 08 2013 21:31:31 GMT+0200 (Paris, Madrid (heure d’été))
+    console.log("Current stratum : "); 
+    console.log(stratum); // 3
+});
+```
+
 ## Contributors
  * Clément Bourgeois (https://github.com/moonpyk)
  * Callan Bryant (https://github.com/naggie)
+ * SomKen (https://github.com/somken)
 
 ## License
 Copyright (c) 2014 Clément Bourgeois

--- a/lib/ntp-client.js
+++ b/lib/ntp-client.js
@@ -21,11 +21,10 @@
     exports.ntpReplyTimeout = 10000;
 
     /**
-     * Fetches the current NTP Time from the given server and port.
+     * Fetches the current NTP Time from the given server and port, including stratum.
      * @param {string} server IP/Hostname of the remote NTP Server
      * @param {number} port Remote NTP Server port number
-     * @param {function(Object, Date)} callback(err, date) Async callback for
-     * the result date or eventually error.
+     * @param {function(Object, Date, number)} callback(err, date, stratum) Async callback for the result date, stratum, or error.
      */
     exports.getNetworkTime = function (server, port, callback) {
         if (callback === null || typeof callback !== "function") {
@@ -85,6 +84,9 @@
                 clearTimeout(timeout);
                 client.close();
 
+                // Extract Stratum (byte 1)
+                var stratum = msg[1];                
+
                 // Offset to get to the "Transmit Timestamp" field (time at which the reply
                 // departed the server for the client, in 64-bit timestamp format."
                 var offsetTransmitTime = 40,
@@ -107,7 +109,7 @@
                 var date = new Date("Jan 01 1900 GMT");
                 date.setUTCMilliseconds(date.getUTCMilliseconds() + milliseconds);
 
-                callback(null, date);
+                callback(null, date, stratum);
             });
         });
     };

--- a/lib/ntp-client.js
+++ b/lib/ntp-client.js
@@ -35,7 +35,7 @@
         port = port || exports.defaultNtpPort;
 
         var client = dgram.createSocket("udp4"),
-            ntpData = new Buffer(48);
+            ntpData = Buffer.alloc(48);
 
         // RFC 2030 -> LI = 0 (no warning, 2 bits), VN = 3 (IPv4 only, 3 bits), Mode = 3 (Client Mode, 3 bits) -> 1 byte
         // -> rtol(LI, 6) ^ rotl(VN, 3) ^ rotl(Mode, 0)
@@ -48,13 +48,9 @@
 
         var timeout = setTimeout(function () {
             client.close();
-            callback("Timeout waiting for NTP response.", null);
+            callback("Timeout waiting for NTP response.", null, null);
         }, exports.ntpReplyTimeout);
 
-        // Some errors can happen before/after send() or cause send() to was impossible.
-        // Some errors will also be given to the send() callback.
-        // We keep a flag, therefore, to prevent multiple callbacks.
-        // NOTE : the error callback is not generalised, as the client has to lose the connection also, apparently.
         var errorFired = false;
 
         client.on('error', function (err) {
@@ -62,7 +58,7 @@
                 return;
             }
 
-            callback(err, null);
+            callback(err, null, null);
             errorFired = true;
 
             clearTimeout(timeout);
@@ -74,7 +70,7 @@
                     return;
                 }
                 clearTimeout(timeout);
-                callback(err, null);
+                callback(err, null, null);
                 errorFired = true;
                 client.close();
                 return;
@@ -85,10 +81,10 @@
                 client.close();
 
                 // Extract Stratum (byte 1)
-                var stratum = msg[1];                
+                var stratum = msg[1];
 
                 // Offset to get to the "Transmit Timestamp" field (time at which the reply
-                // departed the server for the client, in 64-bit timestamp format."
+                // departed the server for the client, in 64-bit timestamp format)
                 var offsetTransmitTime = 40,
                     intpart = 0,
                     fractpart = 0;
@@ -109,6 +105,7 @@
                 var date = new Date("Jan 01 1900 GMT");
                 date.setUTCMilliseconds(date.getUTCMilliseconds() + milliseconds);
 
+                // Return date and stratum in callback
                 callback(null, date, stratum);
             });
         });
@@ -118,13 +115,14 @@
         exports.getNetworkTime(
             exports.defaultNtpServer,
             exports.defaultNtpPort,
-            function (err, date) {
+            function (err, date, stratum) {
                 if (err) {
                     console.error(err);
                     return;
                 }
 
-                console.log(date);
+                console.log('NTP Date:', date);
+                console.log('Stratum:', stratum);
             });
     };
 }(exports));

--- a/lib/ntp-client.js
+++ b/lib/ntp-client.js
@@ -51,6 +51,10 @@
             callback("Timeout waiting for NTP response.", null, null);
         }, exports.ntpReplyTimeout);
 
+        // Some errors can happen before/after send() or cause send() to was impossible.
+        // Some errors will also be given to the send() callback.
+        // We keep a flag, therefore, to prevent multiple callbacks.
+        // NOTE : the error callback is not generalised, as the client has to lose the connection also, apparently.
         var errorFired = false;
 
         client.on('error', function (err) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ntp-client",
     "description": "Pure Javascript implementation of the NTP Client Protocol",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "homepage": "https://github.com/moonpyk/node-ntp-client",
     "author": {
         "name": "Clément Bourgeois",

--- a/test/ntp-client_test.js
+++ b/test/ntp-client_test.js
@@ -61,6 +61,26 @@
 
     };
 
+    exports.validNTPServerStratum = function (test) {
+        ntpClient.getNetworkTime(ntpClient.defaultNtpServer, ntpClient.defaultNtpPort, function (err, date, stratum) {
+            console.log();
+            console.log("System reported : %s", new Date());
+
+            test.ok(err === null);
+            test.ok(date !== null);
+            test.ok(stratum !== null);
+            test.ok(stratum >= 0);
+
+            console.log("NTP Reported : %s", date);
+            console.log("Stratum Reported : %s", stratum);
+
+            // I won't test returned datetime against the system datetime
+            // this is the whole purpose of NTP : putting clocks in sync.
+            test.done();
+        });
+
+    };    
+
     exports.invalidNTPServer = function (test) {
         // I'm pretty sure there is no NTP Server listening at google.com
         ntpClient.getNetworkTime("google.com", 123, function (err, date) {


### PR DESCRIPTION
- Update library to provide access to the stratum info of the given NTP server.
- Updated Readme to include how to get just the time (existing example) and how to get the stratum info too. 
- Fix error in Node 22+ with buffer allocation (See below)
- Add test for stratum

This package seems dead, but as it's still available via npm, I'm making this PR in hopes that it will be added to the main project.  I'm happy to update anything else requested, but this is enough to get me going with my own project. 

Node error seen in v22:
```
(node:60851) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Unit test:
```
$ npm test

> ntp-client@0.5.4 test
> grunt jshint nodeunit

Running "jshint:gruntfile" (jshint) task
>> 1 file lint free.

Running "jshint:lib" (jshint) task
>> 1 file lint free.

Running "jshint:test" (jshint) task
>> 1 file lint free.

Running "nodeunit:files" (nodeunit) task
Testing ntp-client_test.js..
System reported : Sun Dec 29 2024 17:39:36 GMT-0800 (Pacific Standard Time)
NTP Reported : Sun Dec 29 2024 17:39:36 GMT-0800 (Pacific Standard Time)
.
System reported : Sun Dec 29 2024 17:39:36 GMT-0800 (Pacific Standard Time)
NTP Reported : Sun Dec 29 2024 17:39:36 GMT-0800 (Pacific Standard Time)
Stratum Reported : 2
..OK
>> 11 assertions passed (5186ms)

Done.
```